### PR TITLE
Show lambda term and word types in frontend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.10']
         node-version: ['14.x', '16.x']
     steps:
     - uses: actions/checkout@v2

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -6,3 +6,4 @@ psycopg2 --no-binary psycopg2
 pytest
 pytest-django
 pytest-xdist
+-e git+https://github.com/konstantinosKokos/aethel@stable#egg=aethel

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile
 #
-# --no-binary psycopg2
+--no-binary psycopg2
 
+-e git+https://github.com/konstantinosKokos/aethel@stable#egg=aethel
+    # via -r requirements.in
 asgiref==3.7.2
     # via django
 beautifulsoup4==4.12.2
     # via django-livereload-server
-colorama==0.4.6
-    # via pytest
 django==4.2.3
     # via
     #   -r requirements.in
@@ -59,7 +59,5 @@ tornado==6.3.2
     # via django-livereload-server
 typing-extensions==4.7.1
     # via asgiref
-tzdata==2023.3
-    # via django
 urllib3==2.0.4
     # via django-revproxy

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -11,14 +11,21 @@ export const enum SpindleErrorSource {
     GENERAL = "general",
 }
 
+export type LexicalPhrase = {
+    "items": {word: string}[],
+    "type": string
+};
+
 export interface SpindleReturn {
     error?: SpindleErrorSource;
     tex?: string;
     pdf?: string;
     redirect?: string;
+    term?: string;
+    lexical_phrases?: LexicalPhrase[];
 }
 
-export type SpindleMode = "tex" | "pdf" | "overleaf";
+export type SpindleMode = "tex" | "pdf" | "overleaf" | "term-table";
 
 export interface SpindleInput {
     sentence: string;

--- a/frontend/src/app/spindle/spindle.component.html
+++ b/frontend/src/app/spindle/spindle.component.html
@@ -1,4 +1,4 @@
-<h2 class="title" i18n>Spindle</h2>
+<h2 class="title is-2" i18n>Spindle</h2>
 
 <p class="field" i18n>
     Welcome to Spindle. Enter a Dutch sentence in the input field below to start
@@ -14,7 +14,7 @@
             [class.is-danger]="spindleInput.touched && spindleInput.invalid"
             type="text"
             [formControl]="spindleInput"
-            (keydown.enter)="$event.preventDefault()"
+            (keydown.enter)="$event.preventDefault(); parse()"
             placeholder="Enter a sentence..."
             placeholder-i18n
         />
@@ -28,56 +28,86 @@
     </div>
 </form>
 
-<div class="button-container buttons">
+<div class="button-container buttons mb-3">
     <button
-        class="button latex"
-        [class.is-loading]="loading === 'tex'"
-        (click)="export('tex')"
+        class="button"
+        (click)="parse()"
         type="button"
     >
-        <span class="icon">
-            <img src="assets/latex-logo.svg" alt="latex-logo" />
-        </span>
-        <span class="button-text" [class.invisible]="loading === 'tex'" i18n>Export to LaTeX</span>
-    </button>
-    <button
-        class="button pdf"
-        [class.is-loading]="loading === 'pdf'"
-        (click)="export('pdf')"
-        type="button"
-    >
-        <span class="icon">
-            <img src="assets/pdf-logo.svg" alt="pdf-logo" />
-        </span>
-        <span class="button-text" [class.invisible]="loading === 'pdf'" i18n>Export to PDF</span>
-    </button>
-    <button
-        class="button overleaf"
-        (click)="export('overleaf')"
-        type="button"
-    >
-        <span class="icon">
-            <img src="assets/overleaf-logo.svg" alt="overleaf-logo" />
-        </span>
-        <span class="button-text" i18n>Open in Overleaf</span>
+        Parse
     </button>
 </div>
 
-<div class="output-container" *ngIf="texOutput">
-    <button
-        class="button is-small clipboard-copy"
-        type="button"
-        (click)="copyToClipboard()"
-    >
-        <span class="icon">
-            <img src="assets/copy-clipboard.svg" alt="copy to clipboard"
-        /></span>
-        <span i18n>Copy to clipboard</span>
-    </button>
-    <pre
-        name="tex-output"
-        class="is-family-code"
-        [innerText]="texOutput"
-        disabled
-    ></pre>
+<div *ngIf="term && lexicalPhrases">
+    <div class="block is-size-4">{{ term }}</div>
+    <table class="table">
+        <tr *ngFor="let phrase of lexicalPhrases; index as i">
+            <td>
+                {{ i }}
+            </td>
+            <td>
+                <span *ngFor="let item of phrase.items">{{ item.word }} </span>
+            </td>
+            <td>
+                {{ phrase.type }}
+            </td>
+        </tr>
+    </table>
+</div>
+
+<div class="mt-5" *ngIf="parsed">
+    <h4 class="title is-4">Export results</h4>
+    <div class="button-container buttons">
+        <button
+            class="button latex"
+            [class.is-loading]="loading === 'tex'"
+            (click)="export('tex')"
+            type="button"
+        >
+            <span class="icon">
+                <img src="assets/latex-logo.svg" alt="latex-logo" />
+            </span>
+            <span class="button-text" [class.invisible]="loading === 'tex'" i18n>Export to LaTeX</span>
+        </button>
+        <button
+            class="button pdf"
+            [class.is-loading]="loading === 'pdf'"
+            (click)="export('pdf')"
+            type="button"
+        >
+            <span class="icon">
+                <img src="assets/pdf-logo.svg" alt="pdf-logo" />
+            </span>
+            <span class="button-text" [class.invisible]="loading === 'pdf'" i18n>Export to PDF</span>
+        </button>
+        <button
+            class="button overleaf"
+            (click)="export('overleaf')"
+            type="button"
+        >
+            <span class="icon">
+                <img src="assets/overleaf-logo.svg" alt="overleaf-logo" />
+            </span>
+            <span class="button-text" i18n>Open in Overleaf</span>
+        </button>
+    </div>
+
+    <div class="output-container" *ngIf="texOutput">
+        <button
+            class="button is-small clipboard-copy"
+            type="button"
+            (click)="copyToClipboard()"
+        >
+            <span class="icon">
+                <img src="assets/copy-clipboard.svg" alt="copy to clipboard"
+            /></span>
+            <span i18n>Copy to clipboard</span>
+        </button>
+        <pre
+            name="tex-output"
+            class="is-family-code"
+            [innerText]="texOutput"
+            disabled
+        ></pre>
+    </div>
 </div>

--- a/frontend/src/app/spindle/spindle.component.html
+++ b/frontend/src/app/spindle/spindle.component.html
@@ -33,12 +33,14 @@
         class="button"
         (click)="parse()"
         type="button"
+        i18n
     >
         Parse
     </button>
 </div>
 
 <div *ngIf="term && lexicalPhrases">
+    <h4 i18n>Term:</h4>
     <div class="block is-size-4">{{ term }}</div>
     <table class="table">
         <tr *ngFor="let phrase of lexicalPhrases; index as i">
@@ -56,7 +58,7 @@
 </div>
 
 <div class="mt-5" *ngIf="parsed">
-    <h4 class="title is-4">Export results</h4>
+    <h4 class="title is-4" i18n>Export results</h4>
     <div class="button-container buttons">
         <button
             class="button latex"

--- a/frontend/src/app/spindle/spindle.component.ts
+++ b/frontend/src/app/spindle/spindle.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit } from "@angular/core";
 import { FormControl, Validators } from "@angular/forms";
 import { Subject, takeUntil } from "rxjs";
-import { ApiService, SpindleMode } from "../shared/services/api.service";
+import { ApiService, LexicalPhrase, SpindleMode } from "../shared/services/api.service";
 import { ErrorHandlerService } from "../shared/services/error-handler.service";
 import { AlertService } from "../shared/services/alert.service";
 import { AlertType } from "../shared/components/alert/alert.component";
@@ -17,6 +17,10 @@ export class SpindleComponent implements OnInit, OnDestroy {
     });
     texOutput: string | null = null;
     loading: SpindleMode | null = null;
+    term: string | null = null;
+    lexicalPhrases: LexicalPhrase[] = [];
+    parsed: boolean = false;
+
     private destroy$ = new Subject<void>();
 
     constructor(
@@ -45,7 +49,16 @@ export class SpindleComponent implements OnInit, OnDestroy {
                 if (response.pdf) {
                     this.downloadPDF(response.pdf);
                 }
+                if (response.term && response.lexical_phrases) {
+                    this.term = response.term;
+                    this.lexicalPhrases = response.lexical_phrases;
+                    this.parsed = true;
+                }
             });
+    }
+
+    parse() {
+        this.export('term-table');
     }
 
     export(mode: SpindleMode): void {

--- a/frontend/src/app/spindle/spindle.component.ts
+++ b/frontend/src/app/spindle/spindle.component.ts
@@ -19,7 +19,6 @@ export class SpindleComponent implements OnInit, OnDestroy {
     loading: SpindleMode | null = null;
     term: string | null = null;
     lexicalPhrases: LexicalPhrase[] = [];
-    parsed: boolean = false;
 
     private destroy$ = new Subject<void>();
 
@@ -56,13 +55,16 @@ export class SpindleComponent implements OnInit, OnDestroy {
                 if (response.term && response.lexical_phrases) {
                     this.term = response.term;
                     this.lexicalPhrases = response.lexical_phrases;
-                    this.parsed = true;
                 }
             });
     }
 
     parse() {
         this.export('term-table');
+    }
+
+    get parsed(): boolean {
+        return this.term !== null && this.lexicalPhrases.length > 0;
     }
 
     export(mode: SpindleMode): void {


### PR DESCRIPTION
Closes #9  

Some notes:
- The fact that on the frontend `parse()` uses `export()` seems quite backwards, but it made it very easy to add a new response type.
- It isn't ideal that everything is parsed from scratch on every export type (while the spindle-server already provides everything in one call), but in practice it doesn't matter much.
- The proof object passed around is also relevant for #10 