### PR TITLE
Fix infinite loading animation

### DIFF
--- a/backend/spindle/views.py
+++ b/backend/spindle/views.py
@@ -94,7 +94,7 @@ class SpindleView(View):
         )
 
 
-    def read_request(self, request) -> Optional[str]:
+    def read_request(self, request: HttpRequest) -> Optional[str]:
         """Read and validate the HTTP request received from the frontend"""
         request_body = request.body.decode("utf-8")
 
@@ -110,7 +110,7 @@ class SpindleView(View):
 
         return parsed_json['input']
 
-    def latex_response(self, tex) -> JsonResponse:
+    def latex_response(self, tex: str) -> JsonResponse:
         """Return LaTeX code immediately."""
         return SpindleResponse(tex=tex).json_response()
 
@@ -137,7 +137,7 @@ class SpindleView(View):
         pdf_base64_string = base64.b64encode(pdf).decode("utf-8")
         return SpindleResponse(tex=tex, pdf=pdf_base64_string).json_response()
 
-    def overleaf_redirect(self, tex) -> JsonResponse:
+    def overleaf_redirect(self, tex: str) -> JsonResponse:
         """Compose a link to Overleaf."""
         # quote() is used to escape special characters.
         redirect_url = f"https://www.overleaf.com/docs?snip={quote(tex)}"

--- a/frontend/src/app/spindle/spindle.component.ts
+++ b/frontend/src/app/spindle/spindle.component.ts
@@ -31,6 +31,10 @@ export class SpindleComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this.destroy$))
             .subscribe((response) => {
                 this.loading = null;
+                // HTTP error
+                if (!response) {
+                    return;
+                }
                 if (response.error) {
                     this.errorHandler.handleSpindleError(response.error);
                     return;
@@ -64,22 +68,23 @@ export class SpindleComponent implements OnInit, OnDestroy {
         if (!this.texOutput) {
             this.alertService.alert$.next({
                 message: $localize`Failed to copy to clipboard.`,
-                type: AlertType.DANGER
-            })
+                type: AlertType.DANGER,
+            });
             return;
         }
-        navigator.clipboard.writeText(this.texOutput)
+        navigator.clipboard
+            .writeText(this.texOutput)
             .then(() => {
                 this.alertService.alert$.next({
                     message: $localize`Copied to clipboard.`,
-                    type: AlertType.SUCCESS
-                })
+                    type: AlertType.SUCCESS,
+                });
             })
             .catch(() => {
                 this.alertService.alert$.next({
                     message: $localize`Failed to copy to clipboard.`,
-                    type: AlertType.DANGER
-                })
+                    type: AlertType.DANGER,
+                });
             });
     }
 


### PR DESCRIPTION
Closes #6 

When HTTP requests were caught in the `catchError` block, `EMPTY` was returned, which completed the observable and prevented any further requests from being made. This is solved with two changes.

1. The `catchError` block is moved from the outer observable (the click event) to the inner observable (the actual HTTP request). HTTP requests are cancelled while clicks are still registered.

2. The `catchError` block now returns `of(null)`, which is sent to the outer observable so the loading state can be managed properly. The old `EMPTY` cancels the inner observable (without reaching the outer one). I agree that this is a bit odd, semantically, but actually passing an error would cause the outer observable to stop listening.