### PR TITLE
Feature/remove alpino button

### DIFF
--- a/frontend/src/app/menu/menu.component.html
+++ b/frontend/src/app/menu/menu.component.html
@@ -53,15 +53,6 @@
 
                 <a
                     class="navbar-item"
-                    [routerLink]="['/alpino']"
-                    routerLinkActive="is-active"
-                    i18n
-                >
-                    Alpino
-                </a>
-
-                <a
-                    class="navbar-item"
                     [routerLink]="['/about']"
                     routerLinkActive="is-active"
                     i18n

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -55,6 +55,10 @@ const routes: Routes = [
         path: '',
         redirectTo: '/home',
         pathMatch: 'full'
+    },
+    {
+        path: '**',
+        redirectTo: '/home'
     }
 ];
 


### PR DESCRIPTION
As discussed, removes the Alpino button.

I've also added a wildcard route so people who _really_ try to visit `/alpino` or some other non-existing URL are not met with a blank page.